### PR TITLE
Add basic eventing objects

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Salus Scan
         id: salus_scan
         uses: federacy/scan-action@0.1.5
+        env:
+          SALUS_CONFIGURATION: "file://salus-config.yaml"
   release:
     # Publish for a tag starting with v.
     runs-on: ubuntu-latest

--- a/api.yaml
+++ b/api.yaml
@@ -30,6 +30,8 @@ tags:
     description: All the address endpoints
   - name: contract
     description: All the contract endpoints
+  - name: event
+    description: All the event endpoints
 servers:
   - url: http://{ip}:{port}/v2/{symbol}/{network}
     variables:
@@ -436,6 +438,100 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/event/new":
+    post:
+      tags:
+        - event
+      summary: Create a new event
+      operationId: postNewEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Event"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Event"
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/event/delete/{id}":
+    delete:
+      tags:
+        - event
+      summary: Delete a specific event by ID
+      operationId: deleteEventByID
+      parameters:
+        - name: id
+          in: path
+          description: ID of the event to return
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/event/{id}":
+    get:
+      tags:
+        - event
+      summary: Get a specific event by ID
+      operationId: getEventByID
+      parameters:
+        - name: id
+          in: path
+          description: ID of the event to return
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Event"
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/event/list":
+    get:
+      tags:
+        - event
+      summary: Get a list of event associated with the specific token
+      operationId: getEventList
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Event"
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 externalDocs:
   description: Find out more about BlockCypher
   url: "https://blockcypher.com"
@@ -453,20 +549,22 @@ components:
       $ref: "models/AddressKeychain.yaml"
     AddressTransactionSummary:
       $ref: "models/AddressTransactionSummary.yaml"
+    Block:
+      $ref: "models/Block.yaml"
     Chain:
       $ref: "models/Chain.yaml"
     Contract:
       $ref: "models/Contract.yaml"
     ContractAddress:
       $ref: "models/ContractAddress.yaml"
-    Block:
-      $ref: "models/Block.yaml"
-    Transaction:
-      $ref: "models/Transaction.yaml"
+    Event:
+      $ref: "models/Event.yaml"
     Input:
       $ref: "models/Input.yaml"
     Output:
       $ref: "models/Output.yaml"
+    Transaction:
+      $ref: "models/Transaction.yaml"
     TransactionEvent:
       $ref: "models/TransactionEvent.yaml"
     TransactionPayload:

--- a/models/Event.yaml
+++ b/models/Event.yaml
@@ -1,0 +1,56 @@
+# Copyright 2023 BlockCypher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  represents a webHooks notification request.
+type: object
+required:
+  - id
+  - event
+  - url
+properties:
+  id:
+    description: >-
+      Identifier of the event; generated when a new request is created.
+    type: string
+    example: 399d0923-e920-48ee-8928-2051cbfbc369
+  event:
+    description: >-
+      Type of event; can be transaction or block.
+    type: string
+    example: transaction
+  address:
+    description: >-
+      For transaction event, only transactions associated with the given address will be sent.
+    type: string
+    example: 15qx9ug952GWGTNn7Uiv6vode4RcGrRemh
+  confirmations:
+    description: >-
+      For transaction, used to set the number of confirmations desired for which to receive an update.
+      An updated transaction will be sent for every confirmation up to this amount. If set to 0, only 
+      the unconfirmed transaction will be sent
+    type: integer
+    format: uint8
+    example: 5
+  url:
+    description: >-
+      Callback URL for this event's webHook.
+    type: string
+    example: https://my.domain.com/callbacks/transaction
+  callback_errors:
+    description: >-
+      Number of errors when attempting to POST to callback URL.
+    type: integer
+    format: uint8
+    example: 0

--- a/salus-config.yaml
+++ b/salus-config.yaml
@@ -1,0 +1,24 @@
+# https://github.com/coinbase/salus/blob/master/docs/configuration.md
+
+# Used in the report to identify the project being scanned.
+project_name: indigo-sdk
+
+# Defines where to send Salus reports and in what format.
+reports:
+  - uri: file://salus-report.txt
+    format: txt
+
+# All scanners to execute, or the String value "all"/"none"
+active_scanners:
+  - Gosec
+  - PatternSearch
+  - RepoNotEmpty
+  - Semgrep
+  - GoPackageScanner
+  - ReportGoDep
+  - Trufflehog
+
+scanner_configs:
+  Gosec:
+    exclude:
+      - G107

--- a/salus-config.yaml
+++ b/salus-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 BlockCypher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # https://github.com/coinbase/salus/blob/master/docs/configuration.md
 
 # Used in the report to identify the project being scanned.


### PR DESCRIPTION
Add Event object alongside 4 new endpoints:
- /event/create for event creation
- /event/delete/{id} for event deletion
- /event/{id} for event retrieval
- /event/list for full event listing per token.

Endpoint route are still subject to change.