### PR TITLE
Add Contract Read and Write models

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -438,6 +438,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/contract/{contract}/read":
+    post:
+      tags:
+        - contract
+      summary: Interact with contract read only functions
+      operationId: readContract
+      parameters:
+        - name: contract
+          in: path
+          description: String representing the contract address you're interested in interacting with
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContractRead"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContractRead"
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/contract/{contract}/write":
+    post:
+      tags:
+        - contract
+      summary: Interact with contract write functions
+      operationId: writeContract
+      parameters:
+        - name: contract
+          in: path
+          description: String representing the contract address you're interested in interacting with
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContractWrite"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContractWrite"
+        "500":
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/subscription/new":
     post:
       tags:
@@ -551,7 +615,7 @@ components:
       $ref: "models/AddressTransactionSummary.yaml"
     # these two models cannot be represented by a path in this spec
     # but we need them for code generation
-    APIKeyInfo: 
+    APIKeyInfo:
       $ref: "models/APIKeyInfo.yaml"
     APIKeyCount:
       $ref: "models/APIKeyCount.yaml"
@@ -563,6 +627,10 @@ components:
       $ref: "models/Contract.yaml"
     ContractAddress:
       $ref: "models/ContractAddress.yaml"
+    ContractRead:
+      $ref: "models/ContractRead.yaml"
+    ContractWrite:
+      $ref: "models/ContractWrite.yaml"
     Subscription:
       $ref: "models/Subscription.yaml"
     SubscriptionType:

--- a/models/ContractRead.yaml
+++ b/models/ContractRead.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 BlockCypher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  represents a contract read query and response. It is mainly used to call
+  constant function, i.e. functions that do not consume any base units to be
+  executed.
+type: object
+required:
+  - function
+properties:
+  function:
+    description: >-
+      The contract function to call.
+    type: string
+    example: balanceOf
+  params:
+    description: >-
+      Array of parameters if required by the function.
+    type: array
+    items:
+      type: string
+      example: 0xD5f25773d3733937eBe3c11a1781DB4347B7D002
+  results:
+    description: >-
+      Array of addresses involved in the transaction.
+    type: array
+    items:
+      type: string
+      example: 1800000000

--- a/models/ContractWrite.yaml
+++ b/models/ContractWrite.yaml
@@ -1,0 +1,67 @@
+# Copyright 2023 BlockCypher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  represents a contract write query and response. Used to interact with
+  smart contracts. For example, ERC-20 transfer or anything else that
+  requires some kind of execution and as such creates a transaction.
+type: object
+required:
+  - function
+  - private
+properties:
+  function:
+    description: >-
+      The contract function to call.
+    type: string
+    example: balanceOf
+  params:
+    description: >-
+      Array of parameters if required by the function.
+    type: array
+    items:
+      type: string
+      example: 0xD5f25773d3733937eBe3c11a1781DB4347B7D002
+  max_fee_per_gas:
+    description: >-
+      Max Fee Per Gas refer to the max amount a user is willing to pay for their transaction.
+    type: string
+    format: bigint
+    minimum: 0
+    example: 83490998906
+  max_priority_fee_per_gas:
+    description: >-
+      Max Priority Fee Per Gas refer to the max amount a user is willing to give to the miner.
+    type: string
+    format: bigint
+    minimum: 0
+    example: 1000000000
+  results:
+    description: >-
+      Array of addresses involved in the transaction.
+    type: array
+    items:
+      type: string
+      example: 1800000000
+  private:
+    description: >-
+      Private key associated with a funded Ethereum external
+      account used to publish a contract or execute a method.
+    type: string
+    example: 70e5a91bbb7e639b395c0b6e10965330653e2a7713fa6b4d6acf9d2faf2ec097
+  tx_hash:
+    description: >-
+      The hash of the created transaction.
+    type: string
+    example: f854aebae95150b379cc1187d848d58225f3c4157fe992bcd166f58bd5063449


### PR DESCRIPTION
Creates models required to interact with smart contracts.

For now, we've decided to split it into 2 categories: read functions and write functions. Similar to https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7#readContract. 
This allows us to have different objects and requirements for constant calls and call that modifies a contract state. 

We might merge this `/read` and `/write` endpoint to a single `/interact` endpoint later on if this makes sense.